### PR TITLE
Install convenience files

### DIFF
--- a/qextserialport.pro
+++ b/qextserialport.pro
@@ -42,7 +42,8 @@ TEMPLATE=lib
 include(src/qextserialport.pri)
 
 #create_prl is needed, otherwise, MinGW can't found libqextserialport1.a
-CONFIG += create_prl
+CONFIG += create_prl create_pc
+QMAKE_PKGCONFIG_DESTDIR = pkgconfig
 
 #mac framework is designed for shared library
 macx:qesp_mac_framework:qesp_static: CONFIG -= qesp_static

--- a/src/QExtSerialPort
+++ b/src/QExtSerialPort
@@ -1,0 +1,2 @@
+#include "qextserialport.h"
+#include "qextserialenumerator.h"

--- a/src/qextserialport.pri
+++ b/src/qextserialport.pri
@@ -3,7 +3,8 @@ DEPENDPATH += $$PWD
 
 PUBLIC_HEADERS         += $$PWD/qextserialport.h \
                           $$PWD/qextserialenumerator.h \
-                          $$PWD/qextserialport_global.h
+                          $$PWD/qextserialport_global.h \
+                          $$PWD/QExtSerialPort
 
 HEADERS                += $$PUBLIC_HEADERS \
                           $$PWD/qextserialport_p.h \


### PR DESCRIPTION
These patches install convenience files to make it easier to use qextserialport in other projects.

- Install a QExtSerialPort header file, which is the Qt conventional naming style.

- Install a pkg-config file, for integration in build systems different than qmake or cmake.